### PR TITLE
Bugfix/an i3823/fix tic iso to datetime fn

### DIFF
--- a/src/tic.app.src
+++ b/src/tic.app.src
@@ -1,7 +1,7 @@
 {application, tic,
  [
   {description, "Date and time conversion."},
-  {vsn, "1.3.0"},
+  {vsn, "1.3.1"},
   {registered, []},
   {applications,
     [ kernel

--- a/src/tic.erl
+++ b/src/tic.erl
@@ -256,7 +256,7 @@ local_datetime_to_utc(LocalDatetime, UtcOffset) ->
     %% Convert the the seconds in the local timezone to UTC.
     TimezoneMinInt  = binary_to_integer(TimezoneMin),
     TimezoneHourInt = binary_to_integer(TimezoneHour),
-    Offset = ((TimezoneHourInt * 3600 + TimezoneMinInt) * 60),
+    Offset = ((TimezoneHourInt * 60 + TimezoneMinInt) * 60),
     UtcSec =
         case Sign of
             $- -> LocalSec - Offset;

--- a/test/tic_SUITE.erl
+++ b/test/tic_SUITE.erl
@@ -70,7 +70,9 @@ t_iso8601_to_datetime_test(_) ->
     {{2012,05,19},{22,34,55}} =
         tic:iso8601_to_datetime(<<"2012-05-19T22:34:55Z">>),
     {{{2012,11,30},{9,1,0}},486} =
-        tic:iso8601_to_datetime(<<"2012-11-30T09:01:00.486Z">>).
+        tic:iso8601_to_datetime(<<"2012-11-30T09:01:00.486Z">>),
+    {{2018,12,06},{20,0,0}} =
+        tic:iso8601_to_datetime(<<"2018-12-07T00:00:00-04:00">>).
 
 t_gregorian_seconds_to_iso8601_test(_) ->
     GregorianSec =


### PR DESCRIPTION
`(TimezoneHourInt * 3600 + TimezoneMinInt)` should return number of minutes, which are then multiplied by 60 to get seconds